### PR TITLE
refactor: use an unused subnet for single AZ

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ aws:
   - name: vpn-us-east-1
     # We have only a single node and want only a single AZ for EBS volume affinity
     azs: ["us-east-1d"]
-    public_subnets: ["10.10.32.0/20"]
+    public_subnets: ["10.10.48.0/20"]
     node_groups:
     - name: vpn-1a
       desired_size: 1


### PR DESCRIPTION
This allows us to transition to the current cluster without completely tearing it down