### PR TITLE
fix: mount CRL ConfigMap as dir

### DIFF
--- a/helmfile-app/helmfile-vpn.yaml.gotmpl
+++ b/helmfile-app/helmfile-vpn.yaml.gotmpl
@@ -69,7 +69,7 @@ releases:
   - name: vpn-{{ $key }}
     namespace: vpn-{{ $key }}
     chart: oci://ghcr.io/blinklabs-io/helm-charts/charts/openvpn
-    version: 0.7.0
+    version: 0.7.1
     labels:
       app: vpn-{{ $key }}
     condition: vpn.enabled

--- a/helmfile-app/vpn/templates/vpn-instance.yaml.gotmpl
+++ b/helmfile-app/vpn/templates/vpn-instance.yaml.gotmpl
@@ -28,7 +28,7 @@ configFiles:
       ca ca.crt
       cert server.crt
       key server.key
-      crl-verify crl.pem
+      crl-verify crl/crl.pem
       topology subnet
       # This path matches the default from the helm chart
       status /var/tmp/openvpn/openvpn-status.log
@@ -56,6 +56,7 @@ configFiles:
   - name: dh.pem
     content: {{ toYaml .dhParams | indent 6 }}
 
-  - name: crl.pem
+  # NOTE: we mount this in its own dir because the kubelet won't automatically update it
+  # if we specify the key (which uses 'subPath')
+  - name: crl
     configMapName: vpn-ca-crl
-    configMapKey: crl.pem


### PR DESCRIPTION
This allows updates to the ConfigMap to be automatically reflected in the running pod without requiring a restart

Fixes #39