### PR TITLE
ci: add GHA

### DIFF
--- a/.github/workflows/common-helmfile.yml
+++ b/.github/workflows/common-helmfile.yml
@@ -1,0 +1,79 @@
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        required: true
+        type: string
+      arguments:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-helmfile:
+    name: run-helmfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/releases/tag/v4.2.2
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@0c5e050edfed71b2b50731ab044d42489d51c129 # vv4.0.0 https://github.com/Azure/setup-kubectl/releases/tag/vv4.0.0
+        with:
+          version: "v1.32.3"
+
+      - name: Sops Binary Installer
+        uses: mdgreenwald/mozilla-sops-action@d9714e521cbaecdae64a89d2fdd576dd2aa97056 # v1.6.0 https://github.com/mdgreenwald/mozilla-sops-action/releases/tag/v1.6.0
+
+      - name: Setup AWS Profile
+        if: inputs.cluster == 'aws-vpn'
+        run: |
+          mkdir -p ~/.aws
+          cat > ~/.aws/credentials << EOF
+          [vpn_aws]
+          aws_access_key_id = ${{ secrets.VPN_OPS_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key = ${{ secrets.VPN_OPS_AWS_SECRET_ACCESS_KEY }}
+          EOF
+
+          cat > ~/.aws/config << EOF
+          [profile vpn_aws]
+          region = us-east-1
+          EOF
+
+          echo "AWS_PROFILE=vpn_aws" >> $GITHUB_ENV
+
+      - name: Install AWS CLI
+        if: inputs.cluster == 'aws-vpn'
+        run: |
+          set -e
+          # Bail if AWS CLI is already in PATH
+          export PATH=$HOME/bin:$PATH
+          if which aws >/dev/null; then
+            if test -f $HOME/bin/aws; then
+              echo $HOME/bin >> $GITHUB_PATH
+            fi
+            exit 0
+          fi
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          cd aws && ./install -i $HOME/aws-cli -b $HOME/bin --update
+          rm -rf aws awscliv2.zip
+          echo $HOME/bin >> $GITHUB_PATH
+
+      - name: Configure EKS access
+        if: inputs.cluster == 'aws-vpn'
+        run: aws --region us-east-1 eks update-kubeconfig --name vpn-us-east-1
+
+      - name: Run Helmfile
+        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4 https://github.com/helmfile/helmfile-action/releases/tag/v2.0.4
+        with:
+          helmfile-version: "v1.1.5"
+          helm-version: "v3.19.0"
+          helm-plugins: >
+            https://github.com/databus23/helm-diff,
+            https://github.com/jkroepke/helm-secrets
+          helmfile-workdirectory: helmfile-app
+          helmfile-args: "-e ${{ inputs.cluster }} ${{ inputs.arguments }}"
+          helmfile-auto-init: "false"

--- a/.github/workflows/pr-helmfile.yml
+++ b/.github/workflows/pr-helmfile.yml
@@ -1,0 +1,21 @@
+name: pr-helmfile
+on:
+  pull_request:
+    paths:
+      - "helmfile-app/**"
+      - ".github/workflows/pr-helmfile.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pr-helmfile:
+    strategy:
+      matrix:
+        cluster:
+          - aws-vpn
+    secrets: inherit
+    uses: ./.github/workflows/common-helmfile.yml
+    with:
+      cluster: ${{ matrix.cluster }}
+      arguments: "diff"

--- a/.github/workflows/run-helmfile.yml
+++ b/.github/workflows/run-helmfile.yml
@@ -1,0 +1,26 @@
+name: run-helmfile
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "Which cluster to run against"
+        required: true
+        type: choice
+        default: aws-vpn
+        options:
+          - aws-vpn
+      arguments:
+        description: "Helmfile CLI arguments"
+        required: true
+        default: "sync"
+
+permissions:
+  contents: read
+
+jobs:
+  helmfile:
+    secrets: inherit
+    uses: ./.github/workflows/common-helmfile.yml
+    with:
+      cluster: ${{ inputs.cluster }}
+      arguments: ${{ inputs.arguments }}

--- a/.github/workflows/test-helmfile.yml
+++ b/.github/workflows/test-helmfile.yml
@@ -1,0 +1,23 @@
+name: test-helmfile
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "Which cluster to run against"
+        required: true
+        type: choice
+        default: aws-vpn
+        options:
+          - aws-vpn
+
+permissions:
+  contents: read
+
+jobs:
+  helmfile:
+    secrets: inherit
+    uses: ./.github/workflows/common-helmfile.yml
+    with:
+      cluster: ${{ inputs.cluster }}
+      arguments: "diff"

--- a/.github/workflows/test-terraform.yml
+++ b/.github/workflows/test-terraform.yml
@@ -3,8 +3,9 @@ name: test-terraform
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['main']
-    paths: ['config.yaml','terraform/**','.github/workflows/test-terraform.yml']
+    branches: ["main"]
+    paths:
+      ["config.yaml", "terraform/**", ".github/workflows/test-terraform.yml"]
 
 defaults:
   run:

--- a/helmfile-app/grafana-alloy/values.yaml.gotmpl
+++ b/helmfile-app/grafana-alloy/values.yaml.gotmpl
@@ -26,7 +26,6 @@ alloy:
       prometheus.scrape "alloy_check" {
         targets    = discovery.relabel.alloy_check.output
         forward_to = [prometheus.relabel.alloy_check.receiver]
-
         scrape_interval = "60s"
       }
 
@@ -45,8 +44,8 @@ alloy:
           url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
 
           basic_auth {
-            username = "1834751"
-            password = "{{ .Values.grafana.password }}"
+            username = env("GRAFANA_USERNAME")
+            password = env("GRAFANA_PASSWORD")
           }
         }
       }
@@ -118,26 +117,26 @@ alloy:
             "instance" = constants.hostname,
           },
         ]
-      
+
         rule {
           target_label = "job"
           replacement = "integrations/kubernetes/kube-state-metrics"
         }
-      
+
         rule {
           target_label = "cluster"
           replacement = "{{ .Values.eks_lb.clusterName }}"
         }
       }
-      
+
       prometheus.scrape "kube_state_metrics" {
         targets    = discovery.relabel.kube_state_metrics.output
         forward_to = [prometheus.relabel.kube_state_metrics.receiver]
-        
+
         scrape_interval = "60s"
         metrics_path = "/metrics"
       }
-      
+
       prometheus.relabel "kube_state_metrics" {
         forward_to = [prometheus.remote_write.metrics_service.receiver]
 
@@ -153,3 +152,24 @@ alloy:
         level = "info"
         format = "logfmt"
       }
+  extraEnv:
+    - name: GRAFANA_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: grafana-cloud
+          key: GRAFANA_USERNAME
+    - name: GRAFANA_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: grafana-cloud
+          key: GRAFANA_PASSWORD
+
+extraObjects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: grafana-cloud
+  type: Opaque
+  stringData:
+    GRAFANA_USERNAME: "1834751"
+    GRAFANA_PASSWORD: "{{ .Values.grafana.password }}"

--- a/helmfile-app/vars/secrets.yaml
+++ b/helmfile-app/vars/secrets.yaml
@@ -1,5 +1,5 @@
 grafana:
-    password: ENC[AES256_GCM,data:Kk3Bx4fWn++VvZwOSnkcHoOoa/FHgGmqj5oREV8SH+CTIUJSWRaYCY3P8hlLXYxT5FCi1E1NipuOQaflxqEy4Z7alkn8af6cjsfVYfEjjE2xfYmcUFbgu3Gn7nk7lSAAJaFco9J69DI/hB3KOVtmXTWYnuGMRNhcwAGevJnMDZbdl+RguyLqk9YUJEqaV+cOnaKxsRtEBRQ=,iv:Q4clsT09TibmFCnQh6XBWrVJXixzMOFIomVunZ7E1cA=,tag:6yd99xvAIY4UTThyoBeMkg==,type:str]
+    password: ENC[AES256_GCM,data:W/2QfU3k9biS0FPim4WVpWk6djKlvp/0eWQMIW/BnKvItEzj0oQvde1CLZX8o1R4jHitD/MK2wzlRZVode21Y5DYrRRs1sEKM5RbX+IoD7sj/E3wzZmvu2IlEiFhhAL4JeWRecqEZJNnFidK9fV4bvFcVPzF2LkuqdWXt1zO6TP4YIIYGEoP8U1d6EsRceZZEsP9GU4HHds=,iv:2CZVwyW5NdYjP61hOvacpjrGVz3bUGEfVFFTEh13S3c=,tag:1veUnMy0JzZU1KZrB36tSg==,type:str]
 s3:
     #ENC[AES256_GCM,data:VLdb9ERUFm0ksOE0YrIwtJkVlwfXe3CXbDQ53B0RiUK54vAIz02ljVV4kCynm2+yE+jJcg1vswNi,iv:frIrzF6UHZcFxtlVx2gM63tJPNx0YuM4Ygu8BRvtlBg=,tag:+9NkWxA/gRepGcW50YDu0g==,type:comment]
     accessKey: ENC[AES256_GCM,data:NrieoVbuA11VpmpAjsdVuMECcG0=,iv:ejghNiUU8Rs7+FR8Os824R4vGszFeb1rOrphqOc1kro=,tag:JYjN23qtsO88ICvanSlPBQ==,type:str]
@@ -54,7 +54,7 @@ sops:
           created_at: "2025-08-26T20:43:58Z"
           enc: AQICAHhD+6INpe9bWwzJ1I134hpS1h/xe4qIdkxHDi/fxkkAiQFMqgXfRTZHIhfP8NDybMeCAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvfxQ0SaEdSH0SJfxAgEQgDt73qBsIBmGpipj+I6aEtJDA0WJSSFX1lH8Xh4AIPY/X1F4sRN+77JiMsCu5nGFH/75DaGee8itJ2yjvA==
           aws_profile: vpn_aws
-    lastmodified: "2025-10-22T13:16:38Z"
-    mac: ENC[AES256_GCM,data:rwAuk/w74OYVzIE+H1usFLhApa83AIp3FABw7h8U8fcK/KMLKyv1yM9BpkZq52OL1bwCACcDny12gJH1bBhtgGgLK5QVP7zodYqH3ta0Kc3F3n4Ft5lKFc5K/9vmtR70UB0ktcf7PKZEPzYWABXbHumBGoJtFlPFPWSV+MW0VWw=,iv:yEn/njCowb76WPGNJPPA8b5frFtB6OfvgbE+mX3txic=,tag:qqLbL7YOpgnpgRFhVhl83A==,type:str]
+    lastmodified: "2025-11-04T15:35:08Z"
+    mac: ENC[AES256_GCM,data:kaMMeotSqWlh7rBE2B8RDzC4pnApZf2fQV38VNAL4H2bMLOOjbNg8yrAf9VTUPy1ujs3xaATd7s+NZElsHiHDdSjx3Ama/Z1TfCfTpO16cPgx37V6jpf9ouJmBUryxD8VQsq6X86p1Bp152MxzI8jML7AV29VREQ5EaX2gTlfQA=,iv:I6nuaYY3Z0epnNlff6d6TrZZ2N8dqWXxCDnADz7o7J0=,tag:KyLGlvNe5UYbQnbvh6Xnew==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2


### PR DESCRIPTION
closes #13 
- use a secret for credentials


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable CI workflows to run Helmfile operations with selectable cluster and argument inputs, plus PR, manual-run, and test triggers.

* **Security Improvements**
  * Replaced embedded Grafana credentials with environment-sourced secrets and added secret injection for runtime.
  * Updated encrypted secret metadata following a recent secret rotation.

* **Chores**
  * Normalized CI workflow trigger formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->