### PR TITLE
feat(eks): add cluster encryption with new KMS key

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
 aws:
   clusters:
   - name: vpn-us-east-1
+    encryption_config:
+      - provider_key_arn: "arn:aws:kms:us-east-1:705913449309:alias/vpn-eks-encryption"
+        resources: ["secrets"]
     node_groups:
     - name: vpn-1a
       desired_size: 1
@@ -43,6 +46,12 @@ aws:
           - arn:aws:iam::705913449309:user/ops
         aliases:
           - sops
+      - name: eks-encryption
+        description: CMK used to encrypt EKS secrets
+        admins:
+          - arn:aws:iam::705913449309:user/ops
+        aliases:
+          - alias/vpn-eks-encryption
   s3:
     buckets:
       - name: b7s-services-client-profiles

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.0.0, >= 6.11.0, >= 6.20.0, ~> 6.21.0"
   hashes = [
     "h1:YfPC5vxQr014wnHI6tBqLxaHZcZQvkaVr19ipqXijdw=",
+    "h1:cx/bK3Gt1jl9VhRsH44MmKecxdX5FdeKMLl+VozS/r0=",
     "zh:03b65e7d275a48bbe5de9aed2bcacf841ea0a85352744587729d179ceb227994",
     "zh:1a50fc50365602769b6844c6eba920b5c6941161508c2ebd5c1a60f7577edd18",
     "zh:1bcbf2575e462849baa01554be469ac68dbd43fe7929819ab43eb8a849605ce9",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.7"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:dgBaiMxxU61piW30emM6251LMFW66TbKR+p5ylPZvqc=",
     "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
     "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
     "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "h1:wTNrZnwQdOOT/TW9pa+7GgJeFK2OvTvDmx78VmUmZXM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = ">= 0.9.0"
   hashes = [
     "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "h1:P9h9GNlrWPECzIvIFjHOhF+HVzpxk0eCcdy1G0fWSHw=",
     "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
     "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
     "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
@@ -86,9 +90,10 @@ provider "registry.terraform.io/hashicorp/time" {
 
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.1.0"
-  constraints = ">= 3.0.0"
+  constraints = ">= 4.0.0"
   hashes = [
     "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "h1:UklaKJOCynnEJbpCVN0zJKIJ3SvO7RQJ00/6grBatnw=",
     "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
     "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
     "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",

--- a/terraform/aws-eks.tf
+++ b/terraform/aws-eks.tf
@@ -10,4 +10,8 @@ module "eks" {
   private_subnets = try(each.value.private_subnets, [])
   tags            = try(each.value.tags, null)
   node_groups     = try(each.value.node_groups, null)
+  encryption_config = {
+    provider_key_arn = "arn:aws:kms:us-east-1:705913449309:alias/vpn-eks-encryption"
+    resources        = ["secrets"]
+  }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  env_vars              = yamldecode(file("../config.yaml"))
-  aws_account_id        = "705913449309"
-  aws_region            = "us-east-1"
+  env_vars       = yamldecode(file("../config.yaml"))
+  aws_account_id = "705913449309"
+  aws_region     = "us-east-1"
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Add EKS cluster encryption using a new KMS key for enhanced security. This enables envelope encryption for Kubernetes secrets and data at rest.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable EKS secrets encryption using a new KMS key for the vpn-us-east-1 cluster. This secures data at rest and wires encryption config through the Terraform module.

- **New Features**
  - Add encryption_config to config.yaml with the KMS key ARN.
  - Pass encryption_config to the aws_eks module to enable envelope encryption for Kubernetes secrets.
  - Define a new KMS CMK "eks-encryption" with ops admin access and alias.

- **Dependencies**
  - Bump Terraform required_version to >= 1.5.0.

<sup>Written for commit acb1a00550e71f1cb2469dd27095ba128121d69f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-level encryption for EKS using a new KMS customer-managed key to encrypt secrets.

* **Infrastructure Updates**
  * Raised required Terraform version to 1.5.0.
  * Updated provider lock entries and provider version constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->