### PR TITLE
ci: remove security-events write permission and SARIF upload to fix CI failure

### DIFF
--- a/.github/workflows/common-helmfile.yml
+++ b/.github/workflows/common-helmfile.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   run-helmfile:
@@ -32,12 +31,6 @@ jobs:
           scan-ref: 'helmfile-app'
           format: 'sarif'
           output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@b8d3b6e
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
 
       - name: Sops Binary Installer
         uses: mdgreenwald/mozilla-sops-action@d9714e521cbaecdae64a89d2fdd576dd2aa97056 # v1.6.0 https://github.com/mdgreenwald/mozilla-sops-action/releases/tag/v1.6.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the security-events write permission and disabled SARIF upload in the common-helmfile workflow to fix CI failures during Trivy runs. CI now passes; Trivy still scans, but results are no longer uploaded to the Security tab.

- **Bug Fixes**
  - Dropped `security-events: write` from workflow permissions.
  - Removed `github/codeql-action/upload-sarif` step.
  - Kept Trivy scan with SARIF output for local artifact use.

<sup>Written for commit 5858268ce6c07c5222570bf8635c01e5cc3b9f7f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to streamline build processes.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal infrastructure configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->