### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-terraform.yml
+++ b/.github/workflows/test-terraform.yml
@@ -1,4 +1,6 @@
 name: test-terraform
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/blinklabs-io/vpn-infrastructure/security/code-scanning/10](https://github.com/blinklabs-io/vpn-infrastructure/security/code-scanning/10)

To fix the problem, we should add a `permissions` block to the workflow, at either the root level or under the affected job (in this case, under the `terraform` job or globally at the workflow root). The minimal necessary permission is typically `contents: read`, which allows code checkout and is all that's required unless the job needs to write to the repository or interact with other resources. Place the following immediately below the `name:` field if applying globally, or immediately below the affected job's name if job-level permissions are preferred.

Specifically:  
- In `.github/workflows/test-terraform.yml`, add  
  ```yaml
  permissions:
    contents: read
  ```
  either after line 1 (global, applies to all jobs), or after line 17 (specific to the `terraform` job).  
The more idiomatic and maintainable solution is to add it globally, so all jobs inherit least privilege by default.

No imports, definitions, or methods are required—this is a declarative YAML update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a global permissions block to .github/workflows/test-terraform.yml to fix the “Workflow does not contain permissions” code scanning alert and enforce least privilege. All jobs now run with contents: read, which covers checkout and avoids unnecessary access.

<sup>Written for commit d9754a694ca45a2333412dd232cf7e8ff4c2b6b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



