### PR TITLE
fix: use tls-ciphersuites for TLS 1.3

### DIFF
--- a/helmfile-app/vpn/templates/vpn-instance.yaml.gotmpl
+++ b/helmfile-app/vpn/templates/vpn-instance.yaml.gotmpl
@@ -35,7 +35,7 @@ configFiles:
       tls-server
       remote-cert-tls client
       tls-version-min 1.3
-      tls-cipher TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384
+      tls-ciphersuites TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384
       auth SHA256
       tls-cert-profile preferred
       topology subnet


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use tls-ciphersuites for TLS 1.3 in the VPN Helm template, replacing tls-cipher so the configured suites are applied. Prevents TLS 1.3 from ignoring cipher settings and ensures CHACHA20-POLY1305 and AES-256-GCM are used.

<sup>Written for commit 7291cde2b8f10e32f8b6b7e2ab2dfb95b5a322fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VPN configuration to use modern TLS cipher suites for improved security and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->