### PR TITLE
chore: update vpn-indexer for preprod-us1

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -6,7 +6,7 @@ vpn:
   instances:
     preprod-us1:
       # TODO: remove this once we update the version in defaults
-      indexerVersion: '0.9.1'
+      indexerVersion: '0.9.2'
     mainnet-us1:
       # We switched to a new contract in 0.8.1, and we want to keep this instance working on the old contract
       indexerVersion: '0.8.0'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the VPN indexer for preprod-us1 from 0.9.1 to 0.9.2 so preprod runs the latest patch. No changes to other instances.

<sup>Written for commit 2913b09f741640811e78737047b8d18b252a052b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated indexer component version in configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->