### PR TITLE
chore: update vpn-indexer for mainnet-us1-2

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -5,8 +5,7 @@ kube-state-metrics:
 vpn:
   instances:
     preprod-us1:
-      # TODO: remove this once we update the version in defaults
-      indexerVersion: '0.9.2'
+      # NOTE: the defaults are sufficient
     mainnet-us1:
       # We switched to a new contract in 0.8.1, and we want to keep this instance working on the old contract
       indexerVersion: '0.8.0'

--- a/helmfile-app/vars/defaults-vpn.yaml
+++ b/helmfile-app/vars/defaults-vpn.yaml
@@ -26,7 +26,7 @@ vpn:
     network: 10.8.0.0
     mask: 255.255.255.0
 
-    indexerVersion: 0.8.1
+    indexerVersion: 0.9.2
 
     serviceType: LoadBalancer
     serviceAnnotations:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the default VPN indexer version to 0.9.2 and removed the preprod-us1 override, so mainnet-us1-2 will use the latest indexer by default. mainnet-us1 remains pinned to 0.8.0 to keep the old contract working.

<sup>Written for commit e03cc308c9d96ad7e654ea2d609d92e13f5755ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default indexer version to 0.9.2
  * Removed explicit version override from preprod environment to use defaults

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->