### PR TITLE
chore: vpn-indexer 0.9.3 for indexer

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -6,7 +6,7 @@ vpn:
   instances:
     preprod-us1:
       # TODO: remove this once we update the version in defaults
-      indexerVersion: '0.9.2'
+      indexerVersion: '0.9.3'
     mainnet-us1:
       # We switched to a new contract in 0.8.1, and we want to keep this instance working on the old contract
       indexerVersion: '0.8.0'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update vpn-indexer to 0.9.3 for the preprod-us1 VPN instance to pick up the latest release. No other environments changed; mainnet-us1 remains pinned to 0.8.0 for old-contract compatibility.

<sup>Written for commit 9cea4ab21a787c361f568e96ae534d32fe7f5746. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration version for preprod environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->