### PR TITLE
feat: wireguard

### DIFF
--- a/helmfile-app/grafana-alloy/values.yaml.gotmpl
+++ b/helmfile-app/grafana-alloy/values.yaml.gotmpl
@@ -104,8 +104,27 @@ alloy:
             "application" = "openvpn",
             "instance" = constants.hostname,
           },
+          {
+            "__address__" = "wg-preview-us2.wg-preview-us2.svc:8080",
+            "application" = "wireguard",
+            "instance" = constants.hostname,
+          },
         ]
+        forward_to = [prometheus.relabel.custom_targets.receiver]
+        scrape_interval = "30s"
+        metrics_path = "/metrics"
+      }
+
+      prometheus.relabel "custom_targets" {
         forward_to = [prometheus.remote_write.metrics_service.receiver]
+
+        // Keep WireGuard and OpenVPN metrics
+        // WireGuard exporters may use either wg_ or wireguard_ prefix
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|wg_.*|wireguard_.*|openvpn_.*"
+          action = "keep"
+        }
       }
 
       // Kube-state-metrics scraping configuration

--- a/helmfile-app/helmfile-vpn.yaml.gotmpl
+++ b/helmfile-app/helmfile-vpn.yaml.gotmpl
@@ -62,6 +62,7 @@ releases:
     version: 0.5.5
     labels:
       app: vpn-{{ $key }}
+      protocol: openvpn
     condition: vpn.enabled
     values:
       - vpn/values.indexer.yaml.gotmpl
@@ -73,8 +74,38 @@ releases:
     version: 0.9.0
     labels:
       app: vpn-{{ $key }}
+      protocol: openvpn
     condition: vpn.enabled
     values:
       - vpn/values.instance.yaml
       - {{- tpl (readFile "vpn/templates/vpn-instance.yaml.gotmpl") $mergedValues | nindent 8 }}
+  {{- end }}
+
+  # WireGuard releases
+  {{- range $key, $values := .Values.wireguard.instances }}
+  {{-   $wgDefaults := $.Values.wireguard.defaults }}
+  {{-   $mergedValues := (mustMerge $values $wgDefaults (dict "key" $key)) }}
+  - name: wg-indexer-{{ $key }}
+    namespace: wg-{{ $key }}
+    chart: oci://ghcr.io/blinklabs-io/helm-charts/charts/vpn-indexer
+    version: 0.5.5
+    labels:
+      app: wg-{{ $key }}
+      protocol: wireguard
+    condition: wireguard.enabled
+    values:
+      - vpn/values.indexer.yaml.gotmpl
+      - {{- tpl (readFile "wireguard/templates/wg-indexer.yaml.gotmpl") $mergedValues | nindent 8 }}
+
+  - name: wg-{{ $key }}
+    namespace: wg-{{ $key }}
+    chart: oci://ghcr.io/blinklabs-io/helm-charts/charts/wireguard
+    version: {{ $mergedValues.chartVersion | default "0.1.0" }}
+    labels:
+      app: wg-{{ $key }}
+      protocol: wireguard
+    condition: wireguard.enabled
+    values:
+      - wireguard/values.yaml.gotmpl
+      - {{- tpl (readFile "wireguard/templates/wg-instance.yaml.gotmpl") $mergedValues | nindent 8 }}
   {{- end }}

--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -31,3 +31,20 @@ vpn:
         INDEXER_REFERENCE_TOKEN: 949dfe5cf4691b821a09e4017f1894a5dfbf12c02271cbcaa6136c8d.70726f7669646572
         TXBUILDER_PROVIDER_ADDRESS: addr1qygqp4gamrz0j2cfg05y3y3s4uev8gthh6d3t4k9p0xr8jxgx8yp9m2ssx9v9vv60a3xudznxtw68vr8l0rpw26u2gfqtn46y0
         TXBUILDER_SCRIPT_REF_INPUT: ef40fa428ae3485fa089896f577139f3212bff7f7908329d677d387c240103f2#1
+# WireGuard instances
+wireguard:
+  enabled: true
+  instances:
+    preview-us2:
+      # Use latest indexer version with WireGuard support
+      indexerVersion: '0.10.0'
+      extraEnv:
+        INDEXER_NETWORK: preview
+        # This intersect slot/hash is the block before the script and ref token appeared on-chain
+        INDEXER_INTERSECT_HASH: 20cdaec575824dfd5c155e157296ec9ac4ed24eb3f6305a08c7cf6b7f65db825
+        INDEXER_INTERSECT_SLOT: '101294699'
+        INDEXER_SCRIPT_ADDRESS: addr_test1zz50fqklfgvkxey0c0ey3043f7y3dfd68s4mjs7x0kldts4tza0gsjhr8s8v5f6axuprv6utq3h7ctm7xm3zd9fscd6sn2xm2z
+        INDEXER_DELAY_CONFIRMATIONS: '3'
+        INDEXER_REFERENCE_TOKEN: 400d048d3548bde36426a6b7d8d576eb6689ec156d3e7203fe41e0b0.70726f7669646572
+        TXBUILDER_PROVIDER_ADDRESS: addr_test1qp5uud60nh2yl2gw3cu8wj3f23a5kwxnhym9tk45qjujusdtza0gsjhr8s8v5f6axuprv6utq3h7ctm7xm3zd9fscd6s4582zh
+        TXBUILDER_SCRIPT_REF_INPUT: a4ba98190a4dedd6dfc88121f15ff9284bfc44d7d83ed9e1e470fd9b836c80fe#1

--- a/helmfile-app/vars/defaults-vpn.yaml
+++ b/helmfile-app/vars/defaults-vpn.yaml
@@ -67,3 +67,25 @@ vpn:
       ZTJEqg==
       -----END CERTIFICATE-----
 
+# WireGuard defaults
+wireguard:
+  enabled: false
+  instances: {}
+  defaults:
+    # WireGuard listen port (UDP)
+    port: 51820
+    # Server interface address within the VPN subnet (e.g., 10.9.0.1/24 means server gets .1)
+    interfaceAddress: "10.9.0.1/24"
+    # DNS server pushed to clients
+    dns: "1.1.1.1"
+    # Default chart version
+    chartVersion: "0.1.0"
+    # Default indexer version (requires WireGuard support, 0.10.0+)
+    indexerVersion: "0.10.0"
+    # Max devices per subscription
+    maxDevices: 3
+    # Service configuration
+    serviceType: LoadBalancer
+    serviceAnnotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/helmfile-app/vars/local-vpn.yaml
+++ b/helmfile-app/vars/local-vpn.yaml
@@ -7,3 +7,19 @@ vpn:
     local-test:
       serviceType: NodePort
       nodePort: 31194
+
+# WireGuard instances for local development
+# NOTE: Local WireGuard deployment requires these values in secrets.yaml:
+#   - serverPrivateKey: WireGuard server private key
+#   - serverPublicKey: WireGuard server public key
+#   - endpoint: Public endpoint (e.g., "localhost:31820" for local)
+#   - jwtPublicKey: Ed25519 public key for JWT verification
+#   - jwtPrivateKey: Ed25519 private key for JWT signing (in indexer config)
+wireguard:
+  enabled: true
+  instances:
+    local-test:
+      serviceType: NodePort
+      nodePort: 31820
+      # For local development, use placeholder endpoint
+      endpoint: "localhost:31820"

--- a/helmfile-app/vars/secrets.yaml
+++ b/helmfile-app/vars/secrets.yaml
@@ -71,13 +71,29 @@ vpn:
             #ENC[AES256_GCM,data:XT7Hm+s7BEDPkYHB+l9obDhCspecTx5WCNx+WMNazEGK5/tN66w+7gY5WG2MxMr7LrOA1RdxX84G3fujxLN1gDxMjJe+0Z2HBy0=,iv:Dh6QOijl+eS4eMDAB9NRdl41N+ifesvo+Swge1Mgl1c=,tag:k5Euz+vjcUUpwodcm9+EXg==,type:comment]
             serverKey: ENC[AES256_GCM,data:03N9rdHrbwnVYgXkHTAskPhVSU+pF9WWmDjsRxOjPep5lsxTc8bKjPQ8De+mDXZQYwXd/UxJ0luAp86F/h1KXsikUHGC7E3Hk/vYupN6+SSZ3v1rqlLowwk34mAODJosLfvTxnViVnTngyNhBmt0v0+iidJYhZ/UIrHipkvY6wYeK2nQJyBnA4uOt3I6BsBHhXj/YUck3z57jySyfAjqTg9Aq9sTuH/noMvo9QDWzEIHjqp1bTzQ6Ux+tILwq7ApSmcKkzowek0QabeyNos6GBrn/x2VoieGqIz91I49iiYdjyWJbzDuGOwQvxnEWzLZMvyi0veLreCb/bh4A6u4yGK0+QkQ50G9WT0Php0dGHlra7y8MbHM4kZfvyzt6/rTFgpuhYqjHZm1UNPYNFvDYgDZNGRPW+3sg5smAW1YJj+783nq5hQsS5LzdyFIZdTHQ8ikI5De/wqDkwWrmWeb44sH4a6SAnebhr9qoqx0Y+gXiKy23k0DwMGUJT0uoBlGHQ8wLwKzbk51THeVxhEv8h2/Z3zCc9AfVcb5E7UjteERFAdtYWrSph+AUbvkXiXfFFMI94atTmO8uyZVkAzd8OO5v7Ev6BnUSHzJ35iC9kvAlgGFOlmWl54CQ14W9bvMKEyNY+Aax1qL+nMNL3TiXc0TRuna/HeuOIRI5BrvilVqV5EfGO/3qQh6kI/6mWkf2OzKJlFJNuUCp0TdEy6sUxOwkc0x37lr3IQLHoP8Fx/a7tWGpQfCQmP/bu6FMyTrfeej3f0vLgfvu04gdcuEv0mHPMCaCcHoCurdzm06byVdj8FAnlDJ2mPkIxZnY6oQZM+GS/pjFUSS/AVse/+qwCy+yZN3ZUqoywi0Au6sVapBQvru4g1Agb1NTpK6jRvlUm0FKYR89+unD3ztNG7z1gZwosa9iANnEggTk68FCZsG2inv8Q5//6YRqAMDy9nGNDxuOOZarpRMbcVPWAHNtTKg+fmILpimrO6bV/o/SvbJTDXItj9CAYdK6UB5L97SleuwckcwG39j9Ycxt1MjgSOcaH5iiXOw1Udh55+vYmK4AbmxRv2P9370EeHzg/M4SFU0LVHzntdZtMnJT6KG31N2epQXQSlrGmRdkGIrBP/M9w9wDXsTGeKCB1U2UacfsOI2EHCrxNSHDOz3tin//UT8dicowiPDw1BzErQbpLwbOixEHPqXfPSYFg6Cz3iwG2h9w72JcN/UOekoC8zVRstOImsW6qs5ne8yGsYYG9N+Vn8gsoENinCYAMArEE5ve5udl0QyLgWaVre+VDBVIF080hl781b4xJId2/qMpAQnnJHC7nySISXwRRaFm0VLBuE/VaWxNn9A48Qlu6QflRUewCXKY9QGplNbEmDB9kt0R9V2UInSF4tnRezt0L6EtU/2XfnV9EHv26ePbfwGa3GPRoUuhLbhaV4oLTzhI+rziwl0Xyj6/q5L73HiJoVthQ+gTkAT8P3hFj+kOmj6yTLQAIgrx6D463FUNwcRO4DEf3It9UXsTkJwH7TynQOvaLll5ysXO/hxJTHK4XfBbzmh6whkRXwpyC+RQcW6sK0X/GT+zuMWF2cQAZ0+uFZxLxLZ4fJVwv8ncaSY0xS+NTeNhBUgwTXr0h/nAVL34kGnej9hSrNFz5YiVnNEyxsozwojyHPYD7qt1BzkM56zV8+IuvgBBTfIUp0ga9dTlvWQgsR8hEDymVE20oM8YV2Dlne5eLhgHI0w1Hu1SXg/DlsQyA+trqFoVtxhv9ck4I+DUYB3YFciqdpVqjQNpH32WiXUEUCUKcMM2f0MVwQcCKkAyW+IXohCakwUtkQ5K8ZhzSnA/5LmXN75yBS/aW3yud03YhnlFKbqVcgfWWV4sSPRY4tWYlaYtv8aQ3l45hXgwhujk2dNeewDDmbOZpj55d5fyIvis5ORyyTwr573I7Buf2ETrYlQUxavAyTt5FA49AhkmMA9Zonfmo56+psEuog5SOhWqmXSDQhLGpWRbdXzIvNDcDoVvr62p/v1Mn7itayzlLlymZubzRWb4GELHuIzoLKXQEwBrAi1nCPEBh4jqwpg/Y5dH+PQGQOP1v1Tvjwn17O9zrYIq6iI2L4O/ZrPIV7krfaBISF+uONGMCEjZIsxkb+prPvmKlhwlo5j7GWDKrH/18kMt4ks24eDRMwEiVs1+1WTwysD2qdCAvQ4toFvNiGzLuh95e02hgWVTLeDMKxcLi8B4b5f+O+yzKaWtaZu3MhbQaKe2tnpnV56hKCqEfM=,iv:v7HnqSsXC2zs01tB6VeyRWxhwupGlPghTCt37zatxWg=,tag:SlWJxqzMawI3gW1TKOtucA==,type:str]
 #ENC[AES256_GCM,data:3jLxFjo3ZEV7gcX+0Hko8GMB5tOpWP+B5epZoHF2lKj5bCC/kT4exFQ7/ie2fe8lDYP9Zdz+miox,iv:x1YdXE5yHaSZADLyyjPAfVWMwf2jyzbNr7BvOlOpu9k=,tag:RUTb8XgTIlSeQbjcYfKB/A==,type:comment]
+wireguard:
+    defaults:
+        #ENC[AES256_GCM,data:+8uWBE0AnO3E/baD1C4fGKNzcBX8ULoflQL/Wxi7nSejzRKsMHB3O0p5Aq0S/79EKosDt2vtK6F5QuFL0A==,iv:c/9i+vlGBZvfQg7eC2xajGoN8EwzqNpHUDpNQ6ofufU=,tag:371S/cA6qIH4qQ/gjAZnnA==,type:comment]
+        jwtPrivateKey: ENC[AES256_GCM,data:6Rj27sO6h+D9/1FS3Cczbk2Cwe2wl0EwNpxfyVLlL1RXik3W9VBX4EyGt7WqgldXX+7PWmZXalCUmumYx5K+cokBQ3ppE3bUXbPULBhAgAL2aepYPY7QCTSIO3M8jsfJo3VIHymhARoDCS7vVcf5p3voqRauFyM=,iv:ICZN3KvsoGtZqEpPItb98Ye2Mus6QKRpJnqYofZNJwY=,tag:1v+V/iGH9WLnXTOYOdk4xA==,type:str]
+        jwtPublicKey: ENC[AES256_GCM,data:f7srg6533PhvFUYKRxardS32AjAROnpduFL2jVKvudwAFEnF+Slu+CueACCvUI4c+a6RA6Dm43UNd0pZ72nFzg+xJlsKy+9u37MK9K2aWOei4W52hkIn161lU62Zqt1q+QvJKCVhSqFACwWKTmpINAc=,iv:dyf4mfLJH/FeO/BwrY/FcdQfBKFdPM3Yo7AILq7gZzE=,tag:udwMLgeTbfOXDwyeG6K9Aw==,type:str]
+    instances:
+        preview-us2:
+            #ENC[AES256_GCM,data:9ECwhjYMGA38FfNZp3zv+aRI67XUqALSrA==,iv:RaGQ8xCkHxofOaxRunmSRvU/E1rsFuLc3Rgaa7LfMpk=,tag:5t6cXkRbKb8zJHrWZMEl8Q==,type:comment]
+            serverPrivateKey: ENC[AES256_GCM,data:wACb5fJu3SjaKvuCeRgcWn7SrCFxLgrg9HVSJp7nGjPV58Dpu8rR+JrKjoo=,iv:RLSJdj1r/miOMO0h4EL1+/nxGes5l6zi1cjLb5OXXjo=,tag:8cXs1q3SSCEIh7cv8Lnwbw==,type:str]
+            serverPublicKey: ENC[AES256_GCM,data:wXSYL2x05TXw8/+91G6pKaAnw0Rr2F+SXF349nDaxnQ+GBA+tOjIAL/zkh0=,iv:OS4Am5W7JDPjQNfr4Z9N5N/OeSsRwQnEjqTNjmtgJH4=,tag:D/SRhZA8pyeeTVkcT16Nwg==,type:str]
+            #ENC[AES256_GCM,data:/dcx5DlKiVcx4oIycckM7jnZDg5bqB9C+CNIlzoKcAD1AmM=,iv:5HJGoOo9DAqom21jpUCJJxzMKg4YBiYfmqWP6jDzY8Y=,tag:qlgBCoDPRdeWoSSibuXpqw==,type:comment]
+            endpoint: ENC[AES256_GCM,data:FDljHr1lXWFF6OPV7zU/N6dCefZAk7gpIIJuXU7o5JACcBM=,iv:kkFGTdqMGKRCirKEHGx4AMfIDYDPS5bDAuEA453tVX4=,tag:rvfWME7JfVLBq4PjE6vAJA==,type:str]
+            #ENC[AES256_GCM,data:vYxyfEAdhA1B7XrZO49uSbrf,iv:K76ksiHbAv0EbK12e+GyZt6Ldrbkqj6vwIn0+63ah88=,tag:v7YcrBQwk36/6Fk22C8+mg==,type:comment]
+            region: ENC[AES256_GCM,data:pmG4k3aeHbPi9Uv3g5g=,iv:EtW9Z/iW6bvFMDyH71Y5vHgQJp9wC6IPaLB0XVTlGrY=,tag:IIEnRgMw9lROE7fmt7fw2A==,type:str]
+            #ENC[AES256_GCM,data:LrcePqL3se/OgrSprhkJ,iv:gIHFJFbJFjAfKFWKovbUD82jq5nhwdDkceFyIiuWtn0=,tag:MMOtnNhN4BV9C5LRvnvo3A==,type:comment]
+            domain: ENC[AES256_GCM,data:N7nogZfgeqOyHykZf/HFJDkNYgXBzEie,iv:v4V1UvMx0CzKbrGlmb/KcWNr/gqoUymhSDqw+pfvJoQ=,tag:8UsLBg/Qn6pa1T7+aUxRyA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:705913449309:key/d0644d1b-ee39-416c-ad43-ff50f6d7c8de
           created_at: "2025-08-26T20:43:58Z"
           enc: AQICAHhD+6INpe9bWwzJ1I134hpS1h/xe4qIdkxHDi/fxkkAiQFMqgXfRTZHIhfP8NDybMeCAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvfxQ0SaEdSH0SJfxAgEQgDt73qBsIBmGpipj+I6aEtJDA0WJSSFX1lH8Xh4AIPY/X1F4sRN+77JiMsCu5nGFH/75DaGee8itJ2yjvA==
           aws_profile: vpn_aws
-    lastmodified: "2025-12-19T15:02:37Z"
-    mac: ENC[AES256_GCM,data:zwXuN0T5siqI3gosy7DYyYaZOnOxTahy2OfJEgbIUpannpz0fGah7r+5NQqoMRTtJylhHBgA/yVoU/twBInR/vqze7jDz4MuBwv20lYhxWLe0cdQ6iY4Rx8n/eoc+Bx80Gdd0zISDqEQwe5YSvMWpjV4f/9bTaK7U1Ed/MhMqkc=,iv:SitRlScsUw7QW/G5AXAx/gnOYxI1Qi19OZwBZHaB/1g=,tag:n4oUqXo3jwNK+DeYkoigGQ==,type:str]
+    lastmodified: "2026-01-24T20:04:15Z"
+    mac: ENC[AES256_GCM,data:o/KamxCvINU4XeKhywolIG5hihL/4ADXd4EE63pRmjKWLjrwCWaAO6UHyKD0Q6KLQ9jf/VB1c2F0Z8DMV9wRB94U6QJ7vXSiijd497FjpQJ54w92eZYW1ujqmjnLsxugiyX7a872PRgqJOT930P22S1CwW2riMrXtxoX3Wdl4Yw=,iv:PpJrV8OkzjrEXM2Tbas+gGzsjh4pnjU+rjuRbb6FYjg=,tag:7YL1kP+xLoMW4Vk/OAS+fA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
+++ b/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
@@ -1,0 +1,59 @@
+# vpn-indexer configuration for WireGuard mode
+# Extends base vpn-indexer values (which provides S3 credentials)
+
+image:
+  tag: '{{ .indexerVersion }}'
+
+# S3 key prefix for this instance (credentials come from base values.indexer.yaml.gotmpl)
+s3:
+  clientKeyPrefix: {{ .key }}/
+  peerPrefix: peers/
+
+# WireGuard-specific configuration
+wireguard:
+  enabled: true
+  endpoint: {{ .endpoint | quote }}
+  serverPubkey: {{ .serverPublicKey | quote }}
+  containerUrl: "http://wg-{{ .key }}:8080"
+  maxDevices: {{ .maxDevices | default 3 }}
+  jwtPrivateKey: |
+    {{- .jwtPrivateKey | nindent 4 }}
+
+# VPN region/domain
+vpn:
+  domain: {{ .domain }}
+  region: {{ .region }}
+  protocol: wireguard
+
+# Extra environment variables
+extraEnv:
+  AWS_REGION: {{ .region | quote }}
+  VPN_PROTOCOL: wireguard
+  VPN_WG_ENDPOINT: {{ .endpoint | quote }}
+  VPN_WG_SERVER_PUBKEY: {{ .serverPublicKey | quote }}
+  VPN_WG_CONTAINER_URL: "http://wg-{{ .key }}:8080"
+  VPN_WG_MAX_DEVICES: "{{ .maxDevices | default 3 }}"
+  VPN_REGION: {{ .region | quote }}
+{{- if hasKey . "extraEnv" }}
+{{ toYaml .extraEnv | indent 2 }}
+{{- end }}
+
+# Service configuration
+service:
+  type: LoadBalancer
+  port: 443
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+{{- if hasKey . "apiAcmCert" }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .apiAcmCert }}
+{{- end }}
+
+# Persistence for SQLite database
+persistence:
+  enabled: true
+  storageClassName: ebs-gp3
+
+# Run as root to work around permissions problems on EBS volumes
+# (same as OpenVPN indexer - see vpn/values.indexer.yaml.gotmpl)
+securityContext:
+  runAsUser: 0

--- a/helmfile-app/wireguard/templates/wg-instance.yaml.gotmpl
+++ b/helmfile-app/wireguard/templates/wg-instance.yaml.gotmpl
@@ -1,0 +1,36 @@
+# WireGuard instance-specific configuration
+# Merged with base values.yaml.gotmpl
+
+{{- if .chartVersion }}
+image:
+  tag: '{{ .chartVersion }}'
+{{- end }}
+
+wireguard:
+  {{- if .port }}
+  port: {{ .port }}
+  {{- end }}
+  {{- if .interfaceAddress }}
+  subnet: "{{ .interfaceAddress }}"
+  {{- end }}
+  {{- if .dns }}
+  dns: "{{ .dns }}"
+  {{- end }}
+  # Server private key from secrets
+  privateKey: {{ .serverPrivateKey | quote }}
+  # Public endpoint for client configs
+  endpoint: {{ .endpoint | quote }}
+
+# JWT public key for validating indexer requests
+api:
+  jwtPublicKey: |
+    {{- .jwtPublicKey | nindent 4 }}
+
+service:
+  type: {{ .serviceType | default "LoadBalancer" }}
+  {{- if hasKey . "nodePort" }}
+  nodePort: {{ .nodePort }}
+  {{- end }}
+  {{- if hasKey . "serviceAnnotations" }}
+  annotations: {{ toYaml .serviceAnnotations | nindent 4 }}
+  {{- end }}

--- a/helmfile-app/wireguard/values.yaml.gotmpl
+++ b/helmfile-app/wireguard/values.yaml.gotmpl
@@ -1,0 +1,45 @@
+---
+# Base values for WireGuard deployments
+# Instance-specific values are merged from wg-instance.yaml.gotmpl
+
+image:
+  repository: ghcr.io/blinklabs-io/docker-wireguard
+  pullPolicy: IfNotPresent
+
+# API server configuration
+api:
+  port: 8080
+
+# WireGuard configuration
+wireguard:
+  port: 51820
+  # Server subnet (CIDR)
+  subnet: "10.9.0.0/24"
+  dns: "1.1.1.1"
+  enableNat: true
+
+# Service configuration for WireGuard UDP traffic (port 51820)
+service:
+  type: LoadBalancer
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+
+# Resources
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "100m"
+  limits:
+    memory: "256Mi"
+    cpu: "500m"
+
+# Security context for NET_ADMIN capability
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+
+# Network policy
+networkPolicy:
+  enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WireGuard VPN support alongside OpenVPN with new Helmfile releases, charts, and configs. Enables a preview-us2 instance and local development, integrates the indexer, secrets, and metrics scraping.

- **New Features**
  - Helmfile: added WireGuard indexer and instance releases with protocol labels; defaults in vars; preview-us2 and local NodePort configs.
  - Templates/values: new wg-instance and wg-indexer values files; port/subnet/DNS, persistence, LoadBalancer service (optional ACM), network policy, and metrics.
  - Indexer: WireGuard mode settings (endpoint, server pubkey, container URL, max devices, JWT private key) with separate S3 prefixes for clients/peers.
  - Observability: Grafana Alloy scrapes WireGuard metrics (static target for preview-us2) and keeps wg_*, wireguard_*, and openvpn_* (30s interval).

- **Migration**
  - To enable in an environment: set wireguard.enabled and define instances with endpoint, server keypair, domain/region, and JWT keys in secrets.
  - Optional: override chart/indexer versions and service type/annotations; add Grafana scrape target for each new WG instance.

<sup>Written for commit 2f24de393035f8ef9d83a65b24ba3392e7e63eda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WireGuard support alongside OpenVPN with multi-instance per-environment configs (local, preview, cloud).
  * New WireGuard defaults (port, interface, DNS), chart/indexer versions, service types (LoadBalancer/NodePort) and AWS load‑balancer annotations.
  * Per-instance WireGuard releases and indexer with JWT-based credentials, configurable endpoints, persistence, and resource defaults.
  * Metrics: enabled scraping for WireGuard/OpenVPN and forwarding with relabeling to remote metrics receiver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->