### PR TITLE
chore: update vpn-indexer to 0.9.4 in preprod/mainnet

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -5,8 +5,7 @@ kube-state-metrics:
 vpn:
   instances:
     preprod-us1:
-      # TODO: remove this once we update the version in defaults
-      indexerVersion: '0.9.3'
+      # NOTE: the defaults work for this instance
     mainnet-us1:
       # We switched to a new contract in 0.8.1, and we want to keep this instance working on the old contract
       indexerVersion: '0.8.0'

--- a/helmfile-app/vars/defaults-vpn.yaml
+++ b/helmfile-app/vars/defaults-vpn.yaml
@@ -26,7 +26,7 @@ vpn:
     network: 10.8.0.0
     mask: 255.255.255.0
 
-    indexerVersion: 0.8.1
+    indexerVersion: 0.9.4
 
     serviceType: LoadBalancer
     serviceAnnotations:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the default vpn-indexer version to 0.9.4 and remove the preprod-us1 override so it uses the new default. mainnet-us1 stays pinned to 0.8.0 to preserve the old contract.

<sup>Written for commit 8a885cf05336d6836e0c68a518570a5cdc4885ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VPN indexer version from 0.8.1 to 0.9.4 in default configuration
  * Simplified preprod configuration to utilize default settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->