### PR TITLE
fix: use correct AWS region for wireguard indexer

### DIFF
--- a/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
+++ b/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
@@ -33,7 +33,7 @@ tx:
 
 # Extra environment variables
 extraEnv:
-  AWS_REGION: {{ .region | quote }}
+  AWS_REGION: us-east-1
   VPN_PROTOCOL: wireguard
   VPN_WG_ENDPOINT: {{ .endpoint | quote }}
   VPN_WG_SERVER_PUBKEY: {{ .serverPublicKey | quote }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set AWS_REGION to us-east-1 for the WireGuard indexer to fix region mismatches and ensure it uses the correct AWS endpoints.
Replaces the templated .region value in the wg-indexer Helm template.

<sup>Written for commit 9e74b98384978a0b9302be3761083cc1e6950593. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS region configuration to use a fixed value instead of a configurable parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->