### PR TITLE
fix: use correct wireguard container URL in indexer config

### DIFF
--- a/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
+++ b/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
@@ -14,7 +14,7 @@ wireguard:
   enabled: true
   endpoint: {{ .endpoint | quote }}
   serverPubKey: {{ .serverPublicKey | quote }}
-  containerUrl: "http://wg-{{ .key }}:8080"
+  containerUrl: "http://wg-{{ .key }}-wireguard-api.wg-{{ .key }}:8080"
   maxDevices: {{ .maxDevices | default 3 }}
   jwtPrivateKey: |
     {{- .jwtPrivateKey | nindent 4 }}
@@ -37,7 +37,7 @@ extraEnv:
   VPN_PROTOCOL: wireguard
   VPN_WG_ENDPOINT: {{ .endpoint | quote }}
   VPN_WG_SERVER_PUBKEY: {{ .serverPublicKey | quote }}
-  VPN_WG_CONTAINER_URL: "http://wg-{{ .key }}:8080"
+  VPN_WG_CONTAINER_URL: "http://wg-{{ .key }}-wireguard-api.wg-{{ .key }}:8080"
   VPN_WG_MAX_DEVICES: "{{ .maxDevices | default 3 }}"
   VPN_REGION: {{ .region | quote }}
 {{- if hasKey . "extraEnv" }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the indexer’s WireGuard container URL to the correct service DNS to prevent connection failures. Updates `wireguard.containerUrl` and `VPN_WG_CONTAINER_URL` to `http://wg-{{ .key }}-wireguard-api.wg-{{ .key }}:8080`.

<sup>Written for commit 005749a0e617340d38317d9a9df15b23f8b1f495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

