### PR TITLE
chore: bump vpn-indexer version for preview-us2

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -26,7 +26,7 @@ wireguard:
   instances:
     preview-us2:
       # Use latest indexer version with WireGuard support
-      indexerVersion: '0.10.1'
+      indexerVersion: '0.10.2'
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the VPN indexer for the `preview-us2` WireGuard instance from 0.10.1 to 0.10.2 to pick up the latest patch fixes.

<sup>Written for commit 8ecafbefa461c98fa2a35671a249039b343a5f6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

