### PR TITLE
chore: bump vpn-indexer version for preview-us2

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -26,7 +26,7 @@ wireguard:
   instances:
     preview-us2:
       # Use latest indexer version with WireGuard support
-      indexerVersion: '0.10.2'
+      indexerVersion: '0.10.3'
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps `vpn-indexer` from 0.10.2 to 0.10.3 for the `preview-us2` WireGuard deployment to align with the latest indexer release. No other environments are changed.

<sup>Written for commit a420fcc3a8244854c04d96b80b78bb884a8ebc34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

