### PR TITLE
chore: add versions to terraform modules

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.41.0"
   constraints = ">= 6.0.0, >= 6.28.0, ~> 6.37"
   hashes = [
+    "h1:P5G2OYd40P7QUS0dM2uw3WJ0y+VzOoIO7RvRRqA62D0=",
     "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
     "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
     "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.7"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:M9TpQxKAE/hyOwytdX9MUNZw30HoD/OXqYIug5fkqH8=",
     "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
     "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
     "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = ">= 0.9.0"
   hashes = [
     "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
     "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
     "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
     "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
@@ -89,6 +93,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",

--- a/terraform/aws-acm.tf
+++ b/terraform/aws-acm.tf
@@ -1,5 +1,5 @@
 module "aws_acm" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git//aws_acm"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_acm/v0.1.0"
 
   certificates = try(local.env_vars.aws.acm.certificates, [])
 }

--- a/terraform/aws-iam.tf
+++ b/terraform/aws-iam.tf
@@ -1,5 +1,5 @@
 module "aws_iam" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git//aws_iam"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_iam/v0.1.0"
 
   users    = try(local.env_vars.aws.iam.users, [])
   policies = try(local.env_vars.aws.iam.policies, [])

--- a/terraform/aws-kms.tf
+++ b/terraform/aws-kms.tf
@@ -1,5 +1,5 @@
 module "aws_kms" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git//aws_kms"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_kms/v0.1.0"
 
   for_each    = { for k in try(local.env_vars.aws.kms.keys, {}) : k.name => k }
   admins      = try(each.value.admins, [])

--- a/terraform/aws-s3.tf
+++ b/terraform/aws-s3.tf
@@ -1,5 +1,5 @@
 module "aws_s3" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git//aws_s3"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_s3/v0.1.0"
 
   buckets = try(local.env_vars.aws.s3.buckets, [])
 }


### PR DESCRIPTION
closes #87

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Terraform modules to tagged versions to ensure reproducible deploys and avoid breaking changes, addressing #87. Set `aws_acm`, `aws_iam`, `aws_kms`, and `aws_s3` to `v0.1.0` and refreshed `.terraform.lock.hcl` provider hashes.

<sup>Written for commit 181078129b8667da41f0da0c9e887ef8d055e551. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure dependencies have been pinned to specific stable versions to enhance deployment consistency and improve environment reproducibility across all infrastructure layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->