### PR TITLE
chore: update submit API URLs

### DIFF
--- a/helmfile-app/vars/secrets.yaml
+++ b/helmfile-app/vars/secrets.yaml
@@ -8,7 +8,7 @@ vpn:
     defaults:
         kupoUrl: ENC[AES256_GCM,data:ktp6Xfue/xQt876Qibu5i7OrLCLT6b4Ag2mZRNRDeRa3vA==,iv:I0fesVNmWbe+q43Uq3NXv1SyjVUvF8o0iDvxVKeRiZM=,tag:LFWekA1TusWWY/6lwALKzA==,type:str]
         ogmiosUrl: ENC[AES256_GCM,data:sAjEr+Qil4Rza3BYK2Qli7OTJpIb4NMM76VVAnh6kQo=,iv:88McYlvXC2XcFKvN8A1yE2BW0qtUuxhebs9lgDO0CJ4=,tag:fCgygqkxJAuow+WuXeCOiA==,type:str]
-        submitUrl: ENC[AES256_GCM,data:m84r484EsYj5AxKgTshKWsAeUpDMQB9xzA7TQ5s/NB+IMtt8KSOn9dld8Ts+U/Fdo0OWCvg=,iv:CtmWNdODCCKMRTogTN6Kan6GAqXc4aIia/DN4u8uTiE=,tag:mjjUXmNmhWv2YQWtl+317w==,type:str]
+        submitUrl: ENC[AES256_GCM,data:YrumIg3VfQQ15vm8lvHzYb1TBKXGcaiIkWtdD4spe/yi/alDnVQwgVMUM1p+q6vEwVc=,iv:NYQK9DVTFU+tjZBx3/0OqFs973fDOxUjOyO5C42pxDI=,tag:hrWGPOCnIPi/Jn6YT6tfaw==,type:str]
         #ENC[AES256_GCM,data:HGMmC5dIPdh6Jx4u/JMpOA==,iv:zb0R0/yDSj2MIUbNDUsZ34Woh7wIhztl521/4GIAhL0=,tag:yR4CPMYNuYgzuSfGTUFzsA==,type:comment]
         #ENC[AES256_GCM,data:OfVMrZZp6PwgOMC5VSFCkC6Zp8ot,iv:xiVLKrZcnIMXtnL50pkoE+Z94DX5gW1ZIYFXxi6LMA8=,tag:lTbZtS8mIJmwMZ2bvEipQQ==,type:comment]
         dhParams: ENC[AES256_GCM,data:/oxwG/gcBn16Li2Jn64nHPcJr/c+gHqjDZx7BWGxDxDKFuYGVP1v6csR3Z8oXgDFQ7eU2AhwPMyuJKFA4QsvXvG9FbW1DAVOsMGMjPtKpEVnPWv8qqUskIcbmOY9vm4AjUZgNkxUhgrGUVKg/PAqtF/Z4q3k6zUCnuQJ409izTuVaqfLsGzKLAxFyXJgqxoRZNXDHaDV0AoTPLV0vgm0ieQ+xaWA9VQue9X9Oe6dHp4/drKlOJRr7BneIljl9txQT8uzoftqthG/Q+IdCv5G4gN1v6XbHjnaf/r1Mij+naJo/kCHioD2PCit/cTeAACfNaxWgb5AsL2LYX8KT8XNiuIenJtDPTW94rSQgjAf1WDl6Uxe7JvwrpYjBf56jRhTUdEZtjUdxQTJUINuH7vj3VbXv4P7G5wsguqZ8jkOl5UkAK8KUXA+cwNsau3O1frEB7P+4l2i3F7FbunDtTBJ05tEesnoaJhQV9Nnj3XVcfU9ZPgGkhuDfLFUfV5M/XRzqysFk3gIbXt1PMX5Mj+aYzN/XWpkxD+4krjaq3nJSfq+2sSiKNhLww==,iv:L4d6UVTBHlxpqfvZ3mrw+jCgxCFK6mgwpgDeCIeXujY=,tag:8o/62tqzsLMEa030WtdrRg==,type:str]
@@ -18,7 +18,7 @@ vpn:
                 external-dns.alpha.kubernetes.io/hostname: ENC[AES256_GCM,data:ySdkpMMTXMhW/6YRvwbOafhpH4hwQaxdMVQ=,iv:x9jeof5poXJd42WkAbp+dNANVyt70KWtSxWOOzVcHYs=,tag:aasBOgAsK5GSJM89oSb5wg==,type:str]
             kupoUrl: ENC[AES256_GCM,data:JLxebX6dRFySR4ZhrYAnyFu9BaFxGfAEv9JKg2sqn5Zlzw==,iv:ptEATK6pmwIJgt8w+hfb1fx2XWp/LLektQ3bw/I8FTU=,tag:DQvmi+Bqktbb6LWgsshNbQ==,type:str]
             ogmiosUrl: ENC[AES256_GCM,data:21mdqu9DaciEKo495tzuALKGJz9ENKP27NGpZi8v+Kw=,iv:sx5ZOCHsSMfhSU9PZxdgGPN5yRIqx+3tejXwc//gOWk=,tag:dzgOZIIMROZwLVgx/zNWQA==,type:str]
-            submitUrl: ENC[AES256_GCM,data:d5cBzPR4tNB4EQNkAPHQsw9oovbSzSpeohk3GPaUVneZeGwu2JHjWn9Ic06PbhU2VWxrZwk=,iv:XeDZxcp3G/QGKcFyssjAKBcS4+XWS4vVGAps4oGTZNY=,tag:xL3xCo4UaZkBrCSdWoTXYQ==,type:str]
+            submitUrl: ENC[AES256_GCM,data:JV9imG9WzcdroLyFlfKxSYYI/QWM5EnCJhvK17vMl3RXA5XDHqRC83HCbAdPv0ooCrY=,iv:GFHtwACyYAXHgyeX44f1mYBwb68AY0UH0sxkMMq2Y0o=,tag:mOQJzuc+CCxcsHbDW1Wq1Q==,type:str]
             domain: ENC[AES256_GCM,data:0QdoCtb9ytexXqnsf8+u/aPAyFpYKw==,iv:eKa6SQ+bWKzwsPnUqeId0KUL09LF3Jl5E7YR7amTC34=,tag:dl+4nZ3CBrenLo9bKybZjw==,type:str]
             apiHostname: ENC[AES256_GCM,data:TScPZAuOnOaAbZcjs1dYAIgClpsc5JDJ,iv:mTnHu+qRrkDq39WAyg+tew8ParpdDOBiKsf7pMOFT3Q=,tag:QHVZXUElfz8wksX19ywBGA==,type:str]
             #ENC[AES256_GCM,data:I4PL+9c1v7r4ICw1olcKYbvdzQTxzohcGu1SoemKyVfVtUNz6NM=,iv:lW5cLaXaRfXMYeba2utFOpHu4ir0+SYBVM9fX+6cVzY=,tag:ryGyw3ut5Cr+EFSmYZ+RxQ==,type:comment]
@@ -70,7 +70,7 @@ wireguard:
                 external-dns.alpha.kubernetes.io/hostname: ENC[AES256_GCM,data:PBykXikkG6t7wynDNc0vw73+7f87lR41OlA=,iv:BJN9XbkpoxjUty6EUtlvN4uo//sIA9SoQzGO7YLEeP8=,tag:rsSwNfuAFnQMJNJ1thDcIQ==,type:str]
             kupoUrl: ENC[AES256_GCM,data:ZT35krJVdrB0Mtj7xL26J/ekwrtKv+1s+74M0Y6jgn5X6w==,iv:3+gPlEcKKADH8dVW1K0Xu6moLGxyr+DjJiu72mNk8s0=,tag:1/6V4DaQC6AAMZ195QrLxg==,type:str]
             ogmiosUrl: ENC[AES256_GCM,data:ECycO2QqfH+kQIPbJ16Gbyzc66kzEexkPbQij7kvclk=,iv:sDrM6gMPnCBCNZrYmD1Dj8jVBDC4B4M3rMKMViTKMwg=,tag:+UCYcu6fufaRn+/HdtOymQ==,type:str]
-            submitUrl: ENC[AES256_GCM,data:IclSyd6g+1ED0e3LbUD6/PG6bl+VicJ8JGLs3QXdTYjcOIVWhYHn5DUDxDH1Wd/xVVuqhrY=,iv:w5UNkajGin4tepVyl03gLX08tKOQPc0oE0R0bMHud5I=,tag:c8itltozYVpPFbchwRdGYQ==,type:str]
+            submitUrl: ENC[AES256_GCM,data:b7oDKGRbb1fz1WzeVbkYR+7WnOUCf2HFL8ekaxfwNb+ivTxQIwxvTcjb6cWiZH/OVVQ=,iv:EjE+9Zd1LfxRq5E+poJsFFUi709mElgVJA11pPNS2FA=,tag:FxbVlj1JIDvt6Qc8phPPXA==,type:str]
             #ENC[AES256_GCM,data:5vmC3lFqHmRTWZt4e6ii61uRvFQXnR6wEw==,iv:pNT5wcUhU/qxST0Ii//19kpA2/1AvFpq6s1KLU5EVWU=,tag:0E2IwsczdKLnwJTIPrptTg==,type:comment]
             serverPrivateKey: ENC[AES256_GCM,data:a4IcZ/dYN8fKF3Bb8rgco9vjUCvJoTFB6rkkLV1Jv/F/+K8Lm4OXpE7lhLw=,iv:FL4OSD+TzdcHMQGqf5fnZVuSxVMKkUFdKNHc93HhCOc=,tag:GtrNWZp1XsUX+1D1e5usgQ==,type:str]
             serverPublicKey: ENC[AES256_GCM,data:mrccD3/f1VKQA1pkTQ317fibtzO30bnewNQayiZ2Sw5KOAXv+YMxt1Fphuc=,iv:6ova8Q1xMOFzm83uy/qQ4cHuysFYTLiSWCSdsfwE8Tg=,tag:HKAYd1TJobUX78zv+56Dqg==,type:str]
@@ -89,7 +89,7 @@ sops:
           created_at: "2026-03-26T15:16:04Z"
           enc: AQICAHhD+6INpe9bWwzJ1I134hpS1h/xe4qIdkxHDi/fxkkAiQGnZ/7yhgNgTaPXFgCAkQ8KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEOzBepOzfVWNXf+AgEQgDv2UwksoehgxnnEu9kETegvzUwA+4Q+SgdnGv26s7b22cGiHj4vJL8NUzk2rxKn3gscAKROMfBzAmgCfw==
           aws_profile: ""
-    lastmodified: "2026-03-26T15:16:04Z"
-    mac: ENC[AES256_GCM,data:KCSbWktvJkk3hYxlZvoS6qnTo7Djc6W6SNmRXljaz2dTqPqCdmPa3HUnQ2+/4x7tgoXeCt+mX7ykGR/yBk9WGd17drfCKaaeAVO40BpnTiRdoDA26a05UEccXwZeBwX3OcKkjt12PRVdCeeXrG80JD2HxXj1ErLC4tVK6Bah7mI=,iv:Klbs+4DKmzyYPsnoqBkX9xf7RmR6HFttHp0dr68Kl/0=,tag:KzYcIDWcXsSYqZTiqSpe0g==,type:str]
+    lastmodified: "2026-05-25T15:47:50Z"
+    mac: ENC[AES256_GCM,data:laVhc5jR7y9/acCVUkBJc3YcEaoJ+L1Z7wR5YU8kF4Hl9qGSM8wfom5SZNd9fL+pSTljE9emMdllVy7CEGvx+55kYTqvUNjR+JRl3QCwHWb0yHodXo5iKo6CyiJcFdyrOophaentLqBk2URnLrdSNt9F2eIApy8qc3lKM6THxK0=,iv:gT7a9K2tuetZ4z0xyGnGkLxcH46Kuk8IvSLPzsItImA=,tag:MlW2+r1TiYBhAK40AvEYCg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated encrypted `submitUrl` endpoints in `helmfile-app/vars/secrets.yaml` for VPN (defaults and cluster) and WireGuard to route transaction submissions to the new API. Updated SOPS metadata; no other URLs or behavior changed.

<sup>Written for commit 418609dc825059187b380b2b78c9e47d0d564c49. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated encrypted configuration values in deployment secrets and refreshed associated metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/vpn-infrastructure/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->