### PR TITLE
fix(helm-app): update aws_eks module version tag to fix external-dns-irsa iam permission issue

### DIFF
--- a/helmfile-app/vars/defaults-vpn.yaml
+++ b/helmfile-app/vars/defaults-vpn.yaml
@@ -12,7 +12,7 @@ eks_lb:
   enabled: true
   clusterName: vpn-us-east-1
   serviceAccount:
-    roleArn: "arn:aws:iam::705913449309:role/vpn-us-east-1-aws-lb-controller-20250821145900281600000003"
+    roleArn: "arn:aws:iam::705913449309:role/vpn-us-east-1-aws-lb-controller"
 
 storageclasses:
   ebs-gp3:

--- a/terraform/aws-eks.tf
+++ b/terraform/aws-eks.tf
@@ -1,5 +1,5 @@
 module "eks" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.3"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.4"
 
   for_each        = { for c in try(local.env_vars.aws.clusters, {}) : c.name => c }
   cluster_name    = each.value.name


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `aws_eks` Terraform module to v0.2.4 and aligns the ALB controller role ARN, fixing the `external-dns` IRSA IAM permission issue in the vpn-us-east-1 cluster.

- **Bug Fixes**
  - Terraform: bump to `aws_eks/v0.2.4` to include corrected IRSA policy bindings for `external-dns`.
  - Helm: point ALB controller service account to `arn:aws:iam::705913449309:role/vpn-us-east-1-aws-lb-controller` to match the Terraform-managed role and avoid drift.

<sup>Written for commit 4c1224273ef1ac6be818980c1856b9a339ab545d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated EKS load balancer service account configuration with a stable IAM role reference, replacing a temporary identifier with a permanent role name for improved configuration consistency and reliability.
  * Upgraded EKS infrastructure module to the latest patch version to incorporate upstream improvements and ensure continued compatibility with current infrastructure standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->