### PR TITLE
fix(eks): increase vpn-1a node group desired_size to 2 to fix pending pod

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ aws:
       - "arn:aws:route53:::hostedzone/*"
     node_groups:
     - name: vpn-1a
-      desired_size: 1
+      desired_size: 2
       metadata_options:
         # This is needed to allow EC2 metadata calls to work in a containerized environment.
         # This was previously the default of the upstream EKS module


### PR DESCRIPTION
## Problem
`vpn-indexer-0` in namespace `vpn-mainnet-us1-2` has been stuck in `Pending` state for 13h with the error:

```
0/1 nodes are available: 1 Too many pods. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.
```

The single `t4g.medium` node has a hard pod ceiling of **17** and was already running **17/17** pods, leaving no room for `vpn-indexer-0`.

## Fix
Increase `desired_size` from `1` to `2` in `config.yaml` for the `vpn-1a` node group, providing a second node with capacity for the pending pod.

## Verification
After `terraform apply`:
- A second node joins the cluster.
- `vpn-indexer-0` schedules immediately.
- Grafana alert clears.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `desired_size` of the `vpn-1a` EKS node group from 1 to 2 to unblock scheduling of `vpn-indexer-0` in `vpn-mainnet-us1-2`. Adds a second `t4g.medium` node to clear the pending pod caused by the 17-pod limit.

<sup>Written for commit ab8eb33074f780a175a0fe9d3fbe8a4ee29271d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved VPN service reliability and capacity to enhance availability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->