### PR TITLE
chore: update vpn-indexer to v0.10.4 for wg-preview-us2

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -26,7 +26,7 @@ wireguard:
   instances:
     preview-us2:
       # Use latest indexer version with WireGuard support
-      indexerVersion: '0.10.3'
+      indexerVersion: '0.10.4'
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/helmfile-app/vars/secrets.yaml
+++ b/helmfile-app/vars/secrets.yaml
@@ -75,7 +75,7 @@ wireguard:
             serverPrivateKey: ENC[AES256_GCM,data:a4IcZ/dYN8fKF3Bb8rgco9vjUCvJoTFB6rkkLV1Jv/F/+K8Lm4OXpE7lhLw=,iv:FL4OSD+TzdcHMQGqf5fnZVuSxVMKkUFdKNHc93HhCOc=,tag:GtrNWZp1XsUX+1D1e5usgQ==,type:str]
             serverPublicKey: ENC[AES256_GCM,data:mrccD3/f1VKQA1pkTQ317fibtzO30bnewNQayiZ2Sw5KOAXv+YMxt1Fphuc=,iv:6ova8Q1xMOFzm83uy/qQ4cHuysFYTLiSWCSdsfwE8Tg=,tag:HKAYd1TJobUX78zv+56Dqg==,type:str]
             #ENC[AES256_GCM,data:Hp3ZMYeEN+ctF9eeQSX+42zN7SA6+xrAJkUgKuAX2mqTE84=,iv:WSvF4vIsg0UjypVxMiLjnMEFRrUdKhMsafV9k3h1Dqw=,tag:v57f8uU/Es6j3hVkflUUVw==,type:comment]
-            endpoint: ENC[AES256_GCM,data:gJwzH6xa5BSdF6vW/zzeKOvM1uCKsnhnxVh5SOqcD0cd1HI=,iv:l/QEjmJDFZ4BC2EKk5ku8xY99wNVyEXzsDqTs4aUoIE=,tag:/hXszOqEbvtJkuxuoutQ5w==,type:str]
+            endpoint: ENC[AES256_GCM,data:dE/NfIstrTnGh6UAkx+Qg8hRYYcG/z19vWmQKDlaQKo=,iv:tEtRr1MrQDsrFtT8ZtHovsyGkrkraWeZOsh+qvwRHCQ=,tag:OwdG1oNh+weG22xwggsAWw==,type:str]
             #ENC[AES256_GCM,data:sYzkaAZmN+uEAEH2G7fryyQF,iv:WQyUgGUGr6T/fJdWQokVr7b8fzGF5LpFefiQipU/Kp4=,tag:gW00kMRjFQX3jO7Eu1PSdQ==,type:comment]
             region: ENC[AES256_GCM,data:KUouDTw/v7dw/Fy4zbU=,iv:Z5heNLTMYpDQYX3tEgn1hUGMtuDltTrsgR1xrklBoPs=,tag:ARG8/mF1/OQz5hrjzmFDyg==,type:str]
             #ENC[AES256_GCM,data:nLpFKZuEY7pXG1piYjZY,iv:alcnPOkcatuqRO64Hpfwe4ee5CsEAq6K+xWtVV01qBQ=,tag:t9dq9VdKOqtH9X6Q8h61Lw==,type:comment]
@@ -89,7 +89,7 @@ sops:
           created_at: "2026-03-26T15:16:04Z"
           enc: AQICAHhD+6INpe9bWwzJ1I134hpS1h/xe4qIdkxHDi/fxkkAiQGnZ/7yhgNgTaPXFgCAkQ8KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEOzBepOzfVWNXf+AgEQgDv2UwksoehgxnnEu9kETegvzUwA+4Q+SgdnGv26s7b22cGiHj4vJL8NUzk2rxKn3gscAKROMfBzAmgCfw==
           aws_profile: ""
-    lastmodified: "2026-03-26T15:16:04Z"
-    mac: ENC[AES256_GCM,data:KCSbWktvJkk3hYxlZvoS6qnTo7Djc6W6SNmRXljaz2dTqPqCdmPa3HUnQ2+/4x7tgoXeCt+mX7ykGR/yBk9WGd17drfCKaaeAVO40BpnTiRdoDA26a05UEccXwZeBwX3OcKkjt12PRVdCeeXrG80JD2HxXj1ErLC4tVK6Bah7mI=,iv:Klbs+4DKmzyYPsnoqBkX9xf7RmR6HFttHp0dr68Kl/0=,tag:KzYcIDWcXsSYqZTiqSpe0g==,type:str]
+    lastmodified: "2026-06-03T19:40:45Z"
+    mac: ENC[AES256_GCM,data:Ykjll2x5VXI5XIVYHD46ueAiF4Ln9YMMTO9J3RZgrZsrHx7MyUFkbQ97KYL7rBaQCJ34YNg90pMLYwYZGhWtURVLUrFkybKtY6sFhNl/ezRmx7D/si/ijE3iczEPH0z5UYYJPn0saFIn4FgzHkq6vGeT7as0dpKHfLiaBGAjzf8=,iv:z8VJkWA8aTnXX78afEgTbs4YtY8qmk+TPVE6YwYCYkI=,tag:rN7HLoSbF4+yUKRi9CDbQQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `vpn-indexer` to v0.10.4 for the WireGuard `preview-us2` instance to pick up the latest fixes. Rotates the encrypted WireGuard endpoint and refreshes SOPS metadata.

<sup>Written for commit 66ade5a3b483ee9b74186c8cdc61216b793b432f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WireGuard indexer version to 0.10.4
  * Updated WireGuard endpoint configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->