### PR TITLE
fix(eks): Scale up instance_type to t4g.large

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,8 @@ aws:
       - "arn:aws:route53:::hostedzone/*"
     node_groups:
     - name: vpn-1a
-      desired_size: 2
+      desired_size: 1
+      instance_type: t4g.large
       metadata_options:
         # This is needed to allow EC2 metadata calls to work in a containerized environment.
         # This was previously the default of the upstream EKS module

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ aws:
       - "arn:aws:route53:::hostedzone/*"
     node_groups:
     - name: vpn-1a
-      desired_size: 1
+      desired_size: 2
       metadata_options:
         # This is needed to allow EC2 metadata calls to work in a containerized environment.
         # This was previously the default of the upstream EKS module


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `instance_type` to `t4g.large` and increased `desired_size` to 2 for EKS node group `vpn-1a` to unblock `vpn-indexer-0` scheduling in `vpn-mainnet-us1-2`. The previous single `t4g.medium` node was at 17/17 pods; these changes provide headroom.

<sup>Written for commit 17835cdc1636123379ea2585af6203c339651135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

