### PR TITLE
chore: bump aws eks v0.2.5

### DIFF
--- a/terraform/aws-eks.tf
+++ b/terraform/aws-eks.tf
@@ -1,5 +1,5 @@
 module "eks" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.4"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.5"
 
   for_each        = { for c in try(local.env_vars.aws.clusters, {}) : c.name => c }
   cluster_name    = each.value.name


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump Terraform EKS module to `aws_eks/v0.2.5` to pick up the latest fixes and improvements. Updates the module source URL from `v0.2.4`.

<sup>Written for commit ebde964b51866fa6478aedc2df28c9f7f27c7a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS EKS infrastructure module to the latest version while preserving existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->