### PR TITLE
chore: update vpn-indexer for wg-preview-us2

### DIFF
--- a/helmfile-app/helmfile-vpn.yaml.gotmpl
+++ b/helmfile-app/helmfile-vpn.yaml.gotmpl
@@ -69,7 +69,7 @@ releases:
   - name: vpn-indexer
     namespace: vpn-{{ $key }}
     chart: oci://ghcr.io/blinklabs-io/helm-charts/charts/vpn-indexer
-    version: 0.6.0
+    version: 0.7.0
     labels:
       app: vpn-{{ $key }}
       protocol: openvpn
@@ -98,7 +98,7 @@ releases:
   - name: wg-indexer-{{ $key }}
     namespace: wg-{{ $key }}
     chart: oci://ghcr.io/blinklabs-io/helm-charts/charts/vpn-indexer
-    version: 0.6.0
+    version: 0.7.0
     labels:
       app: wg-{{ $key }}
       protocol: wireguard

--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -26,7 +26,7 @@ wireguard:
   instances:
     preview-us2:
       # Use latest indexer version with WireGuard support
-      indexerVersion: '0.10.4'
+      indexerVersion: '0.11.1'
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
+++ b/helmfile-app/wireguard/templates/wg-indexer.yaml.gotmpl
@@ -48,6 +48,9 @@ tx:
   ogmiosUrl: {{ .ogmiosUrl }}
   submitUrl: {{ .submitUrl }}
 
+jwtPrivateKey: |
+  {{- .jwtPrivateKey | nindent 4 }}
+
 # Extra environment variables
 extraEnv:
   AWS_REGION: us-east-1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `vpn-indexer` to 0.7.0 and bump WireGuard indexer to 0.11.1 for `preview-us2`, with JWT private key wiring added to the wg-indexer config.

- **Dependencies**
  - `vpn-indexer` Helm chart: 0.6.0 → 0.7.0 (OpenVPN and WireGuard releases)
  - WireGuard `indexerVersion` (preview-us2): 0.10.4 → 0.11.1

- **New Features**
  - Pass `jwtPrivateKey` to wg-indexer values to enable JWT auth configuration.

<sup>Written for commit 993d5a10c554af5c9d9d640a524b92981f4809d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

