### PR TITLE
chore: update terraform aws_eks module version tag to v0.2.6

### DIFF
--- a/terraform/aws-eks.tf
+++ b/terraform/aws-eks.tf
@@ -1,5 +1,5 @@
 module "eks" {
-  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.5"
+  source = "git::https://github.com/blinklabs-io/terraform-modules.git?ref=aws_eks/v0.2.6"
 
   for_each        = { for c in try(local.env_vars.aws.clusters, {}) : c.name => c }
   cluster_name    = each.value.name


### PR DESCRIPTION
Closes: #115 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Terraform `aws_eks` module reference from v0.2.5 to v0.2.6. This pulls in the latest fixes and keeps our EKS provisioning current.

<sup>Written for commit 8aaf7d84a5ef97caf8d28908294ed0ec1d5fb457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Amazon EKS infrastructure module to a newer upstream version.
  * Existing cluster configuration and settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->