### PR TITLE
feat: deploy wireguard support in preprod

### DIFF
--- a/helmfile-app/vars/aws-vpn.yaml
+++ b/helmfile-app/vars/aws-vpn.yaml
@@ -24,6 +24,12 @@ vpn:
 wireguard:
   enabled: true
   instances:
+    preprod-us2:
+      # Use latest indexer version with WireGuard support
+      indexerVersion: '0.11.1'
+      serviceAnnotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
     preview-us2:
       # Use latest indexer version with WireGuard support
       indexerVersion: '0.11.1'

--- a/helmfile-app/vars/secrets.yaml
+++ b/helmfile-app/vars/secrets.yaml
@@ -65,6 +65,24 @@ wireguard:
         jwtPrivateKey: ENC[AES256_GCM,data:M4m+maRn92TSjqAXCCBLjYKMPWN3xGnVvnck8G6uJV025efL9YKDpgTI90A91B+wiunjqipfYb/Osui15IsJFHk215qmIbqOonIThQUTsy9+ThfURrylpXVjfGAG7xs/2MrVOa7oIYkX3PVArQYQCRWclsmbMIA=,iv:nv6z1N+XKbWuiCBRcJY67tENSYbh+b9xqfTZSqcVYCU=,tag:RvzjTHWWZlCDFiYxjIO4ag==,type:str]
         jwtPublicKey: ENC[AES256_GCM,data:4Kud7S+Oq5r+5ThwlMzSessPhPsO2gCEqsR/RKvTc1yGaDNmPkDPzceM5oYZ3jnLvhyvD07HFwRXjtxrZjWyedBvpiWEgve0pncPcSwx1KsOnowp7LOhbxug6F3BmexOJlU8od2Fln6ZZpqJWWbF6d4=,iv:mCdOFqra+5+yAiVzUyWt1tAagmyyS3fPSQv+Ww2GvQM=,tag:Q0FaMSzK/so0vkb+etnIfg==,type:str]
     instances:
+        preprod-us2:
+            serviceAnnotations:
+                external-dns.alpha.kubernetes.io/hostname: ENC[AES256_GCM,data:2ED5ylPMaeqnzA6MqwvOE23whDENYPeF5sg=,iv:VTbB8deHN1gFdk8nCN9+v6T9St7HEZB0FB/CpcyCH04=,tag:Iy2xwMftvxVCr0DLQYusWQ==,type:str]
+            kupoUrl: ENC[AES256_GCM,data:XBbnpU95an9evkiOcQ9hfweH6fxi1WueKkDAiRyGY2Zf4g==,iv:ucydbyC4rso8jC9EObQQJFH66XWd80TAk7rZmSpfz9o=,tag:qFXJyAKnIttEwXAR1vNR/Q==,type:str]
+            ogmiosUrl: ENC[AES256_GCM,data:G5bSmGN6vKadXXo55Dv2lTGHB1MyXJv+bH/4yvguOV0=,iv:G/X67ckS1Uos0Ph31mO3cLtoGBXBxP5/gN3l/IuLc4A=,tag:0yeZs/dbsO822/choaBBUg==,type:str]
+            submitUrl: ENC[AES256_GCM,data:y2qTdrUp6abQwsaegucF5bhldd4DA1y9/pmAEn5kq/oaaiAYO88qL5EzS8yQu1vCBWwIdG0=,iv:S3sECsd2/49ItCxopxTmMl72SatwTkGgpr8S3TaKPRE=,tag:FXGXLIBqnc4bl+SfPwBYJg==,type:str]
+            #ENC[AES256_GCM,data:R+EQlBkm+W+ZXM1tk/XODU2umH0pGqrc6w==,iv:57PB2VFGC3rZ+i8S1qqCpZf1Da2yw+n0AoMfpOC9/D8=,tag:SJ8k/xJI57+euLwEJuW23A==,type:comment]
+            serverPrivateKey: ENC[AES256_GCM,data:UHEFbdQZ9xtOsYvHCphILzx+3lB+YqN9s+gNOzbwV90+vYitUoKPFZPIbzc=,iv:sMiPVls4VOj12Tp7afgZk614f+oCl2uca1e7j/9bH7Q=,tag:XQhhNTjrCHnKE9jUKbA3pw==,type:str]
+            serverPublicKey: ENC[AES256_GCM,data:eY3qyxX0e+GNmww4Cnug+XpExAZnA8y2v9A0PBF127iCOYs6zjFHH0rfOag=,iv:938QKeKEjzYrRafDEJF6ldVAV2gvmgcaq+avuf/yP/k=,tag:sQj79A6PuNRGS5YWFDDY2w==,type:str]
+            #ENC[AES256_GCM,data:79KF8jalufhIL03suHMlc31904NNbu4Lnx0q+PKnogAtyu4=,iv:KYZTFq9QvEKFIXbfq6VaZcfVODMDFl3CdWzKMWEERxg=,tag:XCm9vuHjEvWTbqhpNxpx4A==,type:comment]
+            endpoint: ENC[AES256_GCM,data:aan9T6l3LUUtvAufjNd+WXrYvunFth2LgClMn4txC0c=,iv:EC64dSHaDU7mdcRhECRus96k5weWSDXxV124jR8cYms=,tag:urdfXsc8xib4oWsn89RzJg==,type:str]
+            #ENC[AES256_GCM,data:1f+wS3/tpar/+N/rHbVTUTo3,iv:xqaOvzdktk3Q96Rq5ye9L8geUHxgSMxxyVWqYY2XZN0=,tag:Lh28BtKITALsj2bqQkkSYg==,type:comment]
+            region: ENC[AES256_GCM,data:k6DYRGmv/NXkT+qOuQ8=,iv:A6cEC33BJFMMF6upA0FCSgth4BK4YAAx54fQjKfpha8=,tag:Gk/v0vIONTmjNRyUM/kPww==,type:str]
+            #ENC[AES256_GCM,data:BapQ8jbZF2VW9dTGpExl,iv:CNKppdNSWC0jIBRHJOGvG6vhA/kutXgUdGw9u2l6p7M=,tag:P3C6pS93Bnxaoy70FqXjkA==,type:comment]
+            domain: ENC[AES256_GCM,data:K5SU0fR+snXz4SiJ3zpu4L/qLvn27YLe,iv:h2F35sTjbfy+eWf10R0lA32wO9orzCcRj0hjVZbgSh4=,tag:Joh0pVllGgGJG35VAVlR2g==,type:str]
+            apiHostname: ENC[AES256_GCM,data:ReGlxzPuSL0VxdeYEqyHYD4l4i98/RZ2,iv:ZPSTsx2PM5RYtvCIdN2dlfL+ofIL0j7Mvy+28B2Tupc=,tag:l3CVqKXJv0MZEZmh2nr7Ow==,type:str]
+            #ENC[AES256_GCM,data:6Um2HThm7VFQDG8scU6M7iwUIec/uITD8RlBKBPoMbmZvIpFLBI=,iv:GQxWGdJS+grT//X3oazimojTOu/kqbChocKTZBjnTLo=,tag:86Ek+kyLWjIZ8QbL28Qj7w==,type:comment]
+            apiAcmCert: ENC[AES256_GCM,data:SwtW/9+44/AHBBwVsVFM4UOTtyRbuqCKtVv8zmpe69fUtNyV2/nteh3bbkQUlIW6E0Im+3BVxtRapLI9+rMcetY4Jpcdt8lDBQrb1bVbT94d1QA=,iv:YDHVyZjoU3yLGA4oUiyx+kTtEu96q+EDz3khA75YDfY=,tag:jVmBrJR1IKCJAD2aFBxfRg==,type:str]
         preview-us2:
             serviceAnnotations:
                 external-dns.alpha.kubernetes.io/hostname: ENC[AES256_GCM,data:PBykXikkG6t7wynDNc0vw73+7f87lR41OlA=,iv:BJN9XbkpoxjUty6EUtlvN4uo//sIA9SoQzGO7YLEeP8=,tag:rsSwNfuAFnQMJNJ1thDcIQ==,type:str]
@@ -89,7 +107,7 @@ sops:
           created_at: "2026-03-26T15:16:04Z"
           enc: AQICAHhD+6INpe9bWwzJ1I134hpS1h/xe4qIdkxHDi/fxkkAiQGnZ/7yhgNgTaPXFgCAkQ8KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHEOzBepOzfVWNXf+AgEQgDv2UwksoehgxnnEu9kETegvzUwA+4Q+SgdnGv26s7b22cGiHj4vJL8NUzk2rxKn3gscAKROMfBzAmgCfw==
           aws_profile: ""
-    lastmodified: "2026-06-03T19:40:45Z"
-    mac: ENC[AES256_GCM,data:Ykjll2x5VXI5XIVYHD46ueAiF4Ln9YMMTO9J3RZgrZsrHx7MyUFkbQ97KYL7rBaQCJ34YNg90pMLYwYZGhWtURVLUrFkybKtY6sFhNl/ezRmx7D/si/ijE3iczEPH0z5UYYJPn0saFIn4FgzHkq6vGeT7as0dpKHfLiaBGAjzf8=,iv:z8VJkWA8aTnXX78afEgTbs4YtY8qmk+TPVE6YwYCYkI=,tag:rN7HLoSbF4+yUKRi9CDbQQ==,type:str]
+    lastmodified: "2026-07-27T20:37:45Z"
+    mac: ENC[AES256_GCM,data:JFmHVrFMIq9vLrmkM9RaYyVHbglaqhPshA6+FPRlqB7uJ4MhwBJbRbVJeK5YnkKh1UC/vr5+wakobRHhyRPK6fe0OrgxZGc2UuL0w1cF9yJbX2WLe1qscIF1+Xu/PUi/eNKvJiHyeNx9fKinVHui8Nv0M0wdFv1DnqFshMmvWSw=,iv:iDfitVAT7Q9DgfPPlnyLJ5oVdCv2HPRcvfTZCWImEeA=,tag:BrZDO0ecxmzfxPhGiDn82A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables WireGuard in preprod (`preprod-us2`) using indexer `0.11.1`, exposed via an internet-facing AWS NLB. Adds encrypted endpoints, keys, DNS, and ACM settings needed for the deployment.

- **New Features**
  - Adds `preprod-us2` WireGuard instance with NLB (`service.beta.kubernetes.io/aws-load-balancer-type: nlb`) and internet-facing scheme; sets indexer `0.11.1`.
  - Adds SOPS-encrypted config for `preprod-us2`: external-dns hostname, `kupo`/`ogmios`/`submit` URLs, WireGuard server keys, endpoint/region/domain, API hostname, and ACM cert.

<sup>Written for commit 9868b2986e1df142c7ac1518cbe7671c61d9f203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-infrastructure/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pre-production US2 WireGuard instance.
  * Configured internet-facing network load balancing and related service connectivity.
  * Added the required encrypted deployment and networking settings for the new instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->